### PR TITLE
Include clang-tidy binary in the cache fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A fairly simple wrapper application around the clang-tidy executable. It will at
 
 ## Configuration
 
-In order to keep the wrapper reasonably clean, the user will have to write a configuration file at the following location:
+By default, the wrapper will look for the `clang-tidy` executable on the path. This can be changed by setting the `CLANG_TIDY_CACHE_BINARY` environment variable, or by writing a configuration file at the following location:
 
 `~/.ctcache/config.json`
 

--- a/caches/cache.go
+++ b/caches/cache.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ejfitzgerald/clang-tidy-cache/utils"
 	"io"
 	"os"
+	"os/exec"
 )
 
 type Cacher interface {
@@ -15,15 +16,8 @@ type Cacher interface {
 	SaveEntry(digest []byte, content []byte) error
 }
 
-func computeDigestForConfigFile(projectRoot string) ([]byte, error) {
-	configFilePath, err := utils.FindInParents(projectRoot, ".clang-tidy")
-	if err != nil {
-		return nil, err
-	}
-
-	// compute the SHA of the configuration file
-	// read the contents of the file am hash it
-	f, err := os.Open(configFilePath)
+func computeFileDigest(path string) ([]byte, error) {
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +34,26 @@ func computeDigestForConfigFile(projectRoot string) ([]byte, error) {
 	return digest, nil
 }
 
-func ComputeFingerPrint(invocation *clang.TidyInvocation, wd string, args []string) ([]byte, error) {
+func computeDigestForConfigFile(projectRoot string) ([]byte, error) {
+	configFilePath, err := utils.FindInParents(projectRoot, ".clang-tidy")
+	if err != nil {
+		return nil, err
+	}
+
+	return computeFileDigest(configFilePath)
+}
+
+func computeDigestForClangTidyBinary(clangTidyPath string) ([]byte, error) {
+	// resolve to a full path: e.g. `clang-tidy` -> `/usr/local/bin/clang-tidy`
+	path, err := exec.LookPath(clangTidyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return computeFileDigest(path)
+}
+
+func ComputeFingerPrint(clangTidyPath string, invocation *clang.TidyInvocation, wd string, args []string) ([]byte, error) {
 
 	// extract the compilation target command flags from the database
 	targetFlags, err := clang.ExtractCompilationTarget(invocation.DatabaseRoot, invocation.TargetPath)
@@ -66,10 +79,17 @@ func ComputeFingerPrint(invocation *clang.TidyInvocation, wd string, args []stri
 		return nil, err
 	}
 
+	// we also need to include the clang-tidy binary since different version have different output
+	binaryDigest, err := computeDigestForClangTidyBinary(clangTidyPath)
+	if err != nil {
+		return nil, err
+	}
+
 	// combine all the digests to generate a unique fingerprint
 	hasher := sha256.New()
 	hasher.Write(preProcessedDigest)
 	hasher.Write(configDigest)
+	hasher.Write(binaryDigest)
 	fingerPrint := hasher.Sum(nil)
 
 	return fingerPrint, nil

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func evaluateTidyCommand(cfg *Configuration, wd string, args []string, cache cac
 		invocation = other
 
 		// compute the finger print for the file
-		computedFingerPrint, err := caches.ComputeFingerPrint(invocation, wd, args)
+		computedFingerPrint, err := caches.ComputeFingerPrint(cfg.ClangTidyPath, invocation, wd, args)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Hi @ejfitzgerald, thanks for this project! I've found it incredibly useful! 

The speedup is amazing and I'm looking to integrate the cache in a CI pipeline but I've run into a couple of things that don't quite fit into our CI workflow. This PR resolves that and I'm hoping that these changes will be useful for all users.

### `clang-tidy` binary in the cache fingerprint

Let's say that you run `clang-tidy-cache` with `clang-tidy-11` on a project and warm up the cache. Then you upgrade to `clang-tidy-12` and run it again. Currently, that results in all cache hits but that isn't correct: `clang-tidy-12` has new checks that must run. The old cache entries aren't valid for this version. This is an important issue for correctness in CI with a shared cache where `clang-tidy` upgrades can happen on any branch/repo (so it's not practical to wipe the cache).

The fix proposed by this PR is to add the `clang-tidy` binary itself to the cache fingerprint. This ensures that any changes in the executable (like version upgrades) will miss old cache entries. Adding `clang-tidy --version` could have been another option, but SHA256 felt both simpler and more robust.

### Config defaults and environment variable overrides

This one's just about ease of use. It's simpler for users to get started if they don't need to create a config file at all, so this PR provides a default: if there's no config file, simply use the `clang-tidy` that's on the path.

It's also often useful to be able to override the config via env variables without touching the config file: `CLANG_TIDY_CACHE_BINARY` makes that possible. I find the variable easier to automate in CI than writing to a config file.

The priority of the configuration is set up the same way as `ccache`. From highest to lowest priority: 1. Environment variables. 2. Config file. 3. Built-in defaults.