### PR TITLE
Consider directory when extracting compilation target

### DIFF
--- a/clang/compilerDb.go
+++ b/clang/compilerDb.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ejfitzgerald/clang-tidy-cache/utils"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 )
 
 type DatabaseEntry struct {
@@ -39,7 +40,7 @@ func ExtractCompilationTarget(databaseRootPath string, target string) (*Database
 	}
 
 	for _, entry := range db {
-		if entry.File == target {
+		if entry.File == target || entry.File == filepath.Join(entry.Directory, target) {
 			return &entry, nil
 		}
 	}


### PR DESCRIPTION
When generating compile_commands.json from CMake, some *generated target* may generate file paths in the following form:
```
{
  "directory": "/home/joschonb/dev/repo/build/...",
  "command": "/usr/bin/clang++-10 ...",
  "file": "/home/joschonb/dev/repo/build/.../src-file.cc"
},
```
This case, the existing logic to find the compilation target was broken. This fixes the issue.