### PR TITLE
Add basedir config to reuse cache from different directories

### DIFF
--- a/caches/cache.go
+++ b/caches/cache.go
@@ -53,7 +53,8 @@ func computeDigestForClangTidyBinary(clangTidyPath string) ([]byte, error) {
 	return computeFileDigest(path)
 }
 
-func ComputeFingerPrint(clangTidyPath string, invocation *clang.TidyInvocation, wd string, args []string) ([]byte, error) {
+func ComputeFingerPrint(clangTidyPath string, baseDir string, invocation *clang.TidyInvocation,
+	wd string, args []string) ([]byte, error) {
 
 	// extract the compilation target command flags from the database
 	targetFlags, err := clang.ExtractCompilationTarget(invocation.DatabaseRoot, invocation.TargetPath)
@@ -68,7 +69,7 @@ func ComputeFingerPrint(clangTidyPath string, invocation *clang.TidyInvocation, 
 	}
 
 	// main part of the fingerprint check generate the preprocessed output file and create a SHA256 of it
-	preProcessedDigest, err := clang.EvaluatePreprocessedFile(targetFlags.Directory, compileCommand)
+	preProcessedDigest, err := clang.EvaluatePreprocessedFile(targetFlags.Directory, baseDir, compileCommand)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -11,12 +11,14 @@ import (
 	"os/exec"
 	"os/user"
 	"path"
+	"path/filepath"
 )
 
 const VERSION = "0.3.0"
 
 type Configuration struct {
 	ClangTidyPath string                   `json:"clang_tidy_path"`
+	BaseDir       string                   `json:"base_dir"`
 	GcsConfig     *caches.GcsConfiguration `json:"gcs,omitempty"`
 }
 
@@ -60,6 +62,9 @@ func readConfigFile(cfg *Configuration) error {
 func readConfigEnv(cfg *Configuration) {
 	if envPath := os.Getenv("CLANG_TIDY_CACHE_BINARY"); len(envPath) > 0 {
 		cfg.ClangTidyPath = envPath
+	}
+	if envBaseDir := os.Getenv("CLANG_TIDY_CACHE_BASEDIR"); len(envBaseDir) > 0 {
+		cfg.BaseDir = filepath.Clean(envBaseDir)
 	}
 }
 
@@ -152,7 +157,7 @@ func evaluateTidyCommand(cfg *Configuration, wd string, args []string, cache cac
 		invocation = other
 
 		// compute the finger print for the file
-		computedFingerPrint, err := caches.ComputeFingerPrint(cfg.ClangTidyPath, invocation, wd, args)
+		computedFingerPrint, err := caches.ComputeFingerPrint(cfg.ClangTidyPath, cfg.BaseDir, invocation, wd, args)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This feature is equivalent to `CCACHE_BASEDIR` and enables cache reuse across directories. This is needed because some absolute paths can end up in the preprocessed output via `__FILE__` macros or other debugging mechanisms. This causes cache misses even though the code is otherwise identical.

When `CLANG_TIDY_CACHE_BASEDIR`/`base_dir` is set, we replace absolute paths that match that base prefix with relative paths in the preprocessed output.

Additionally, we need to pass the `-P` flag to the preprocessor to avoid linemarker comments that indicate which bit of the output came from which header path.