### PR TITLE
User/joschonb/preprocessor output

### DIFF
--- a/clang/clangArgumentParser.go
+++ b/clang/clangArgumentParser.go
@@ -3,12 +3,12 @@ package clang
 import (
 	"crypto/sha256"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
-	"fmt"
 )
 
 type CompilerCommand struct {
@@ -79,7 +79,7 @@ func EvaluatePreprocessedFile(buildRoot string, command *CompilerCommand) ([]byt
 	cmd.Dir = buildRoot
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
-		fmt.Printf(stdoutStderr)
+		fmt.Printf("%s", stdoutStderr)
 		return nil, err
 	}
 

--- a/clang/clangArgumentParser.go
+++ b/clang/clangArgumentParser.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"fmt"
 )
 
 type CompilerCommand struct {
@@ -76,8 +77,9 @@ func EvaluatePreprocessedFile(buildRoot string, command *CompilerCommand) ([]byt
 	// run the preprocessor
 	cmd := exec.Command(command.Compiler, args...)
 	cmd.Dir = buildRoot
-	err = cmd.Run()
+	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
+		fmt.Printf(stdoutStderr)
 		return nil, err
 	}
 


### PR DESCRIPTION
Currently, when the pre-processor fails with an error, it is impossible to debug what is going on, because the output is swallowed. This change propagates any captured output in case of preprocessor errors.