### PR TITLE
fix: remove PreprocessedFile after closing it

### DIFF
--- a/clang/clangArgumentParser.go
+++ b/clang/clangArgumentParser.go
@@ -86,7 +86,11 @@ func EvaluatePreprocessedFile(buildRoot string, command *CompilerCommand) ([]byt
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() {
+		f.Close()
+		// remove the file (clean up)
+		os.Remove(filename)
+	}()
 
 	hasher := sha256.New()
 	if _, err := io.Copy(hasher, f); err != nil {
@@ -95,13 +99,6 @@ func EvaluatePreprocessedFile(buildRoot string, command *CompilerCommand) ([]byt
 
 	// compute the final digest
 	digest := hasher.Sum(nil)
-
-	// remove the file (clean up)
-	f.Close()
-	err = os.Remove(filename)
-	if err != nil {
-		return nil, err
-	}
 
 	return digest, nil
 }

--- a/clang/clangArgumentParser.go
+++ b/clang/clangArgumentParser.go
@@ -97,6 +97,7 @@ func EvaluatePreprocessedFile(buildRoot string, command *CompilerCommand) ([]byt
 	digest := hasher.Sum(nil)
 
 	// remove the file (clean up)
+	f.Close()
 	err = os.Remove(filename)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes Windows error: `The process cannot access the file because it is being used by another process.`