### PR TITLE
clangArgumentParser: use `shlex` to parse commands

### DIFF
--- a/clang/clangArgumentParser.go
+++ b/clang/clangArgumentParser.go
@@ -3,11 +3,11 @@ package clang
 import (
 	"crypto/sha256"
 	"errors"
+	"github.com/google/shlex"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"strings"
 )
 
 type CompilerCommand struct {
@@ -18,7 +18,10 @@ type CompilerCommand struct {
 }
 
 func ParseClangCommandString(commands string) (*CompilerCommand, error) {
-	words := strings.Fields(commands)
+	words, err := shlex.Split(commands)
+	if err != nil {
+		return nil, err
+	}
 
 	var cmd CompilerCommand
 	cmd.Compiler = words[0]

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/ejfitzgerald/clang-tidy-cache
 
 go 1.15
 
-require cloud.google.com/go/storage v1.14.0
+require (
+	cloud.google.com/go/storage v1.14.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+)

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=


### PR DESCRIPTION
Commands in the JSON database may be escaped for the shell. Perform
unescaping so that escaped characters don't get mangled.